### PR TITLE
Fix: issue#53 delete findSmallestCircle method

### DIFF
--- a/src/main/java/com/group24/decide/LIC.java
+++ b/src/main/java/com/group24/decide/LIC.java
@@ -237,7 +237,7 @@ public class LIC {
             Datapoints a = points[idx];
             Datapoints b = points[idx + parameters.A_PTS + 1];
             Datapoints c = points[idx + parameters.A_PTS + parameters.B_PTS + 2];
-            if (Utility.findSmallestCircle(a, b, c) < parameters.RADIUS1) {
+            if (Utility.calcMinEnclosingRadius(a, b, c) < parameters.RADIUS1) {
                 return true;
             }
         }

--- a/src/main/java/com/group24/decide/Utility.java
+++ b/src/main/java/com/group24/decide/Utility.java
@@ -111,7 +111,7 @@ public class Utility {
         // the smallest radius is circumcircle
         if (biggestAngle < 90) {
             // Circumcircle reference: https://www.mathopenref.com/trianglecircumcircle.html
-           double denominator = (distanceAB*distanceAB*distanceBC);
+           double denominator = (distanceAB * distanceAC *distanceBC);
            double divider = (distanceAB + distanceAC + distanceBC) * (distanceAC + distanceBC - distanceAB) * (distanceBC + distanceAB - distanceAC)*(distanceAB + distanceAC - distanceBC);
            return denominator / Math.sqrt(divider);
         }
@@ -159,35 +159,4 @@ public class Utility {
         return distance;
     }
 
-    /**
-     * Find the radius of the smallest circle that datapoints a, b, c can form.
-     * The smallest circle is the circumscribed circle of the triangle that points a, b, c form if the triangle is acute.
-     * Otherwise the diameter of the smallest circle is the longest line a, b, c can form.
-     * @param a First datapoint
-     * @param b Second datapoint
-     * @param c Third datapoint
-     * @return the radius of the circle
-     */
-    public static double findSmallestCircle(Datapoints a, Datapoints b, Datapoints c){
-        double distanceAB = calcEuclideanDistance(a, b);
-        double distanceAC = calcEuclideanDistance(a, c);
-        double distanceBC = calcEuclideanDistance(b, c);
-
-        // Calculating the circumscribed circle of triangle ABC
-        double cosA = ((b.x - a.x) * (c.x - a.x) + (b.y - a.y) * (c.y - a.y)) / (distanceAB * distanceAC);
-        double sinA = Math.sqrt(1 - cosA * cosA);
-        double radius = distanceBC / (sinA * 2);
-
-        // If the triangle is obtuse, right-angle, or the three points form a line,
-        // then the diameter of smallest circle is the longest line in AB, AC, BC.
-        double cosB = ((a.x - b.x) * (c.x - b.x) + (a.y - b.y) * (c.y - b.y)) / (distanceAB * distanceBC);
-        double cosC = ((a.x - c.x) * (b.x - c.x) + (a.y - c.y) * (b.y - c.y)) / (distanceAC * distanceBC);
-        if (cosA <= 0 || cosB <= 0 || cosC <= 0) {
-            return Math.max(Math.max(distanceAB, distanceAC), distanceBC) / 2;
-        }
-
-        // If the triangle is acute, the smallest circle is its circumscribed circle.
-        return radius;
-
-    }
 }

--- a/src/test/java/com/group24/decide/UtilityTest.java
+++ b/src/test/java/com/group24/decide/UtilityTest.java
@@ -125,31 +125,4 @@ class UtilityTest {
         assertEquals(1.15, minRadius, 0.01);
     }
 
-    @DisplayName("findSmallestCircle")
-    void findSmallestCircle() {
-        // Test case 1: the three points form an acute triangle
-        Datapoints a1 = new Datapoints(-1 * Math.sqrt(2), -1 * Math.sqrt(2));
-        Datapoints b1 = new Datapoints(0, 2);
-        Datapoints c1 = new Datapoints(1 * Math.sqrt(2), -1 * Math.sqrt(2));
-        assertEquals(2, Utility.findSmallestCircle(a1, b1, c1));
-
-        // Test case 2: the three points form a right-angle triangle
-        Datapoints a2 = new Datapoints(-2, 0);
-        Datapoints b2 = new Datapoints(0, 2);
-        Datapoints c2 = new Datapoints(2, 0);
-        assertEquals(2, Utility.findSmallestCircle(a2, b2, c2));
-
-        // Test case 3: the three points form an obtuse triangle
-        Datapoints a3 = new Datapoints(-2, 0);
-        Datapoints b3 = new Datapoints(0, 1);
-        Datapoints c3 = new Datapoints(2, 0);
-        assertEquals(2, Utility.findSmallestCircle(a3, b3, c3));
-
-        // Test case 4: the three points form a line
-        Datapoints a4 = new Datapoints(-2, 0);
-        Datapoints b4 = new Datapoints(0, 0);
-        Datapoints c4 = new Datapoints(2, 0);
-        assertEquals(2, Utility.findSmallestCircle(a4, b4, c4));
-    }
-
 }


### PR DESCRIPTION
Delete findSmallestCircle method and its unit test. Condition8 now uses calcMinEnclosingRadius instead.